### PR TITLE
Add broken link checker workflow

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -1,0 +1,24 @@
+name: Broken link checker
+
+on:
+  # can be used to run workflow manually
+  workflow_dispatch:
+  schedule:
+    # Automatically run on every sunday of the month
+    - cron:  '0 1 * * 0'
+
+jobs:      
+    broken-link-check:
+        runs-on: ubuntu-latest
+        timeout-minutes: 30
+        steps:
+        - name: Check out repository
+          uses: actions/checkout@v4.1.0
+    
+        - name: Link Checker
+          id: lychee
+          uses: lycheeverse/lychee-action@v1.8.0
+          with:
+            fail: true
+          env:
+            GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}} 

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,0 +1,2 @@
+# Ignore file for broken link checker action, anything added here will be ignored lycheeverse/lychee-action@.*
+^https?://www.linkedin.com/in/.*$


### PR DESCRIPTION
- Added a workflow to check for broken links in the repo
- Added a ignore file as the workflow wasn't dealing with LinkedIn links too well
- This workflow can be triggered manually and it will also run on every Sunday(feel free to modify this cron job)